### PR TITLE
Remove unused dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,10 +30,7 @@
     "cache"
   ],
   "dependencies": {
-    "gulp-util": "^3.0.7",
     "through2": "^2.0.1",
-    "glob": "^7.0.3",
-    "lodash": "^4.11.1",
     "vinyl-file": "^2.0.0",
     "sass-graph": "^2.1.1"
   },


### PR DESCRIPTION
gulp-util, glob and lodash are not actually used; remove them from the package dependencies.